### PR TITLE
Fix use of non-existent time zone in fromDateTimeString()

### DIFF
--- a/lib/ical/time.js
+++ b/lib/ical/time.js
@@ -1139,7 +1139,7 @@
         if (prop.parent.name === 'standard' || prop.parent.name === 'daylight') {
           // Per RFC 5545 3.8.2.4 and 3.8.2.2, start/end date-times within
           // these components MUST be specified in local time.
-          zone = ICAL.Timezone.floating;
+          zone = ICAL.Timezone.localTimezone;
         } else if (zoneId) {
           // If the desired time zone is defined within the component tree,
           // fetch its definition and prefer that.


### PR DESCRIPTION
Port of https://github.com/kewisch/ical.js/pull/583